### PR TITLE
Use media store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libuvccommon/build
 libuvc/src/main/libs
 .vscode/settings.json
 app/release/
+.history/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,9 +4,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32"
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"
 	    tools:ignore="ScopedStorage" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-feature android:name="android.hardware.camera"/>
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
 
@@ -27,7 +27,6 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_logo"
         android:theme="@style/Theme.ClinkCameraDemo"
-        android:requestLegacyExternalStorage="true"
         android:largeHeap="true"
         android:supportsRtl="true">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         android:roundIcon="@mipmap/ic_logo"
         android:theme="@style/Theme.ClinkCameraDemo"
         android:requestLegacyExternalStorage="true"
+        android:largeHeap="true"
         android:supportsRtl="true">
 
         <activity

--- a/app/src/main/java/com/jiangdg/demo/DemoFragment.kt
+++ b/app/src/main/java/com/jiangdg/demo/DemoFragment.kt
@@ -66,6 +66,7 @@ import com.jiangdg.demo.databinding.DialogMoreBinding
 import com.jiangdg.utils.MMKVUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 import java.util.*
 
 /** CameraFragment Usage Demo
@@ -412,6 +413,7 @@ class DemoFragment : CameraFragment(), View.OnClickListener, CaptureMediaView.On
                 mViewBinding.recTimerLayout.visibility = View.GONE
                 showRecentMedia(false)
                 stopMediaTimer()
+                MediaStoreUtils.saveMediaStore(File(path!!), requireContext())
             }
 
         })
@@ -434,6 +436,7 @@ class DemoFragment : CameraFragment(), View.OnClickListener, CaptureMediaView.On
             override fun onComplete(path: String?) {
                 showRecentMedia(true)
                 mViewBinding.albumPreviewIv.setNewImageFlag(false)
+                MediaStoreUtils.saveMediaStore(File(path!!), requireContext())
             }
         })
     }

--- a/app/src/main/java/com/jiangdg/demo/MainActivity.kt
+++ b/app/src/main/java/com/jiangdg/demo/MainActivity.kt
@@ -89,16 +89,16 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun permissionList(): Array<String> {
-        return if(Build.VERSION.SDK_INT >= 30) {
-            arrayOf(CAMERA, RECORD_AUDIO) // WRITE_EXTERNAL_STORAGE deprecated
+        return if(Build.VERSION.SDK_INT >= 29) {
+            arrayOf(CAMERA, RECORD_AUDIO)
         } else {
             arrayOf(CAMERA, RECORD_AUDIO, WRITE_EXTERNAL_STORAGE)
         }
     }
 
     private fun checkStoragePermission(): Int {
-        return if(Build.VERSION.SDK_INT >= 30) {
-            0 // WRITE_EXTERNAL_STORAGE deprecated
+        return if(Build.VERSION.SDK_INT >= 29) {
+            0
         } else {
             PermissionChecker.checkSelfPermission(this, WRITE_EXTERNAL_STORAGE)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.1.0'
+        classpath 'com.android.tools.build:gradle:8.10.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ ext {
     javaTargetCompatibility = JavaVersion.VERSION_1_8
     androidXVersion = '1.7.1'
     ndkVersion = '28.1.13356709'
-    supportLibVersion = '27.1.1'
     kotlinCoreVersion = '1.3.2'
     kotlinCoroutines = '1.10.2'
     coreKtx = '1.18.0'

--- a/libausbc/src/main/AndroidManifest.xml
+++ b/libausbc/src/main/AndroidManifest.xml
@@ -5,5 +5,4 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.USB_PERMISSION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 </manifest>

--- a/libausbc/src/main/AndroidManifest.xml
+++ b/libausbc/src/main/AndroidManifest.xml
@@ -2,4 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-feature android:name="android.hardware.usb.host"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 </manifest>

--- a/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
@@ -534,12 +534,19 @@ class MultiCameraClient(ctx: Context, callback: IDeviceConnectCallBack?) {
                 callBack.onError("Has no audio permission")
                 return
             }
-            if (! CameraUtils.hasStoragePermission(mContext)) {
-                callBack.onError("Has no storage permission")
-                return
+            if (mp3Path.isNullOrEmpty()) {
+                File(mCameraAudioDir).apply { if(!exists()) mkdirs() }
+                if (!MediaUtils.isAboveQ()) {
+                    if (!CameraUtils.hasStoragePermission(mContext)) {
+                        callBack.onError("Has no storage permission")
+                        Logger.e(TAG,"captureAudioStart failed, have no storage permission")
+                        return
+                    }
+                }
             }
             val path = if (mp3Path.isNullOrEmpty()) {
-                "${mContext.getExternalFilesDir(null)?.path}/${System.currentTimeMillis()}.mp3"
+                val date = mDateFormat.format(System.currentTimeMillis())
+                "$mCameraAudioDir/AUD_AUSBC_${date}.mp3"
             } else {
                 mp3Path
             }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
@@ -303,7 +303,10 @@ class MultiCameraClient(ctx: Context, callback: IDeviceConnectCallBack?) {
             SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.getDefault())
         }
         protected val mCameraDir by lazy {
-            "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)}/Camera"
+            "${ctx.getExternalFilesDir(Environment.DIRECTORY_DCIM)}/Camera"
+        }
+        protected val mCameraAudioDir by lazy {
+            "${ctx.getExternalFilesDir(Environment.DIRECTORY_MUSIC)}/Camera"
         }
 
         override fun handleMessage(msg: Message): Boolean {

--- a/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
@@ -24,6 +24,7 @@ import com.jiangdg.ausbc.utils.CameraUtils
 import com.jiangdg.ausbc.utils.CameraUtils.isFilterDevice
 import com.jiangdg.ausbc.utils.CameraUtils.isUsbCamera
 import com.jiangdg.ausbc.utils.Logger
+import com.jiangdg.ausbc.utils.MediaUtils
 import com.jiangdg.ausbc.utils.OpenGLUtils
 import com.jiangdg.ausbc.utils.SettableFuture
 import com.jiangdg.ausbc.utils.Utils
@@ -31,6 +32,7 @@ import com.jiangdg.ausbc.widget.IAspectRatio
 import com.jiangdg.usb.*
 import com.jiangdg.usb.DeviceFilter
 import com.jiangdg.uvc.UVCCamera
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -913,6 +915,18 @@ class MultiCameraClient(ctx: Context, callback: IDeviceConnectCallBack?) {
         private fun isEncoding(): Boolean = mVideoProcess?.isEncoding() == true
 
         private fun captureVideoStartInternal(path: String?, durationInSec: Long, callBack: ICaptureCallBack) {
+            if (path.isNullOrEmpty()) {
+                File(mCameraDir).apply { if(!exists()) mkdirs() }
+                if (!MediaUtils.isAboveQ()) {
+                    if (!CameraUtils.hasStoragePermission(mContext)) {
+                        mMainHandler.post {
+                            callBack.onError("have no storage permission")
+                        }
+                        Logger.e(TAG,"captureVideoStartInternal failed, have no storage permission")
+                        return
+                    }
+                }
+            }
             if (! isCameraOpened()) {
                 Logger.e(TAG ,"capture video failed, camera not opened")
                 return

--- a/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/MultiCameraClient.kt
@@ -536,13 +536,6 @@ class MultiCameraClient(ctx: Context, callback: IDeviceConnectCallBack?) {
             }
             if (mp3Path.isNullOrEmpty()) {
                 File(mCameraAudioDir).apply { if(!exists()) mkdirs() }
-                if (!MediaUtils.isAboveQ()) {
-                    if (!CameraUtils.hasStoragePermission(mContext)) {
-                        callBack.onError("Has no storage permission")
-                        Logger.e(TAG,"captureAudioStart failed, have no storage permission")
-                        return
-                    }
-                }
             }
             val path = if (mp3Path.isNullOrEmpty()) {
                 val date = mDateFormat.format(System.currentTimeMillis())
@@ -924,15 +917,6 @@ class MultiCameraClient(ctx: Context, callback: IDeviceConnectCallBack?) {
         private fun captureVideoStartInternal(path: String?, durationInSec: Long, callBack: ICaptureCallBack) {
             if (path.isNullOrEmpty()) {
                 File(mCameraDir).apply { if(!exists()) mkdirs() }
-                if (!MediaUtils.isAboveQ()) {
-                    if (!CameraUtils.hasStoragePermission(mContext)) {
-                        mMainHandler.post {
-                            callBack.onError("have no storage permission")
-                        }
-                        Logger.e(TAG,"captureVideoStartInternal failed, have no storage permission")
-                        return
-                    }
-                }
             }
             if (! isCameraOpened()) {
                 Logger.e(TAG ,"capture video failed, camera not opened")

--- a/libausbc/src/main/java/com/jiangdg/ausbc/base/CameraFragment.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/base/CameraFragment.kt
@@ -267,7 +267,7 @@ abstract class CameraFragment : BaseFragment(), ICameraStateCallBack {
      * Capture image
      *
      * @param callBack capture status, see [ICaptureCallBack]
-     * @param savePath custom image path
+     * @param savePath custom image path, use custom path no auto save to media store, but you can use MediaStoreUtils.saveMediaStore(file: File, context: Context)
      */
     protected fun captureImage(callBack: ICaptureCallBack, savePath: String? = null) {
         getCurrentCamera()?.captureImage(callBack, savePath)
@@ -392,7 +392,7 @@ abstract class CameraFragment : BaseFragment(), ICameraStateCallBack {
      * Capture video start
      *
      * @param callBack capture status, see [ICaptureCallBack]
-     * @param path custom save path
+     * @param path custom save path, use custom path no auto save to media store, but you can use MediaStoreUtils.saveMediaStore(file: File, context: Context)
      * @param durationInSec divided record duration time in seconds
      */
     protected fun captureVideoStart(callBack: ICaptureCallBack, path: String ?= null, durationInSec: Long = 0L) {

--- a/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
@@ -239,15 +239,6 @@ class CameraUVC(ctx: Context, device: UsbDevice) : MultiCameraClient.ICamera(ctx
         mSaveImageExecutor.submit {
             if (savePath.isNullOrEmpty()) {
                 File(mCameraDir).apply { if(!exists()) mkdirs() }
-                if (!MediaUtils.isAboveQ()) {
-                    if (!CameraUtils.hasStoragePermission(mContext)) {
-                        mMainHandler.post {
-                            callback.onError("have no storage permission")
-                        }
-                        Logger.e(TAG,"captureImageInternal failed, have no storage permission")
-                        return@submit
-                    }
-                }
             }
             if (! isPreviewed) {
                 mMainHandler.post {

--- a/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
@@ -283,7 +283,6 @@ class CameraUVC(ctx: Context, device: UsbDevice) : MultiCameraClient.ICamera(ctx
                 Logger.w(TAG, "save yuv to jpeg failed.")
                 return@submit
             }
-            if (savePath.isNullOrEmpty()) MediaStoreUtils.saveMediaStore(File(path), mContext)
             mMainHandler.post {
                 callback.onComplete(path)
             }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/camera/CameraUVC.kt
@@ -15,11 +15,9 @@
  */
 package com.jiangdg.ausbc.camera
 
-import android.content.ContentValues
 import android.content.Context
 import android.graphics.SurfaceTexture
 import android.hardware.usb.UsbDevice
-import android.provider.MediaStore
 import android.view.Surface
 import android.view.SurfaceView
 import android.view.TextureView
@@ -33,6 +31,7 @@ import com.jiangdg.ausbc.camera.bean.CameraRequest
 import com.jiangdg.ausbc.camera.bean.PreviewSize
 import com.jiangdg.ausbc.utils.CameraUtils
 import com.jiangdg.ausbc.utils.Logger
+import com.jiangdg.ausbc.utils.MediaStoreUtils
 import com.jiangdg.ausbc.utils.MediaUtils
 import com.jiangdg.ausbc.utils.Utils
 import com.jiangdg.uvc.IFrameCallback
@@ -238,12 +237,17 @@ class CameraUVC(ctx: Context, device: UsbDevice) : MultiCameraClient.ICamera(ctx
 
     override fun captureImageInternal(savePath: String?, callback: ICaptureCallBack) {
         mSaveImageExecutor.submit {
-            if (! CameraUtils.hasStoragePermission(ctx)) {
-                mMainHandler.post {
-                    callback.onError("have no storage permission")
+            if (savePath.isNullOrEmpty()) {
+                File(mCameraDir).apply { if(!exists()) mkdirs() }
+                if (!MediaUtils.isAboveQ()) {
+                    if (!CameraUtils.hasStoragePermission(mContext)) {
+                        mMainHandler.post {
+                            callback.onError("have no storage permission")
+                        }
+                        Logger.e(TAG,"captureImageInternal failed, have no storage permission")
+                        return@submit
+                    }
                 }
-                Logger.e(TAG,"open camera failed, have no storage permission")
-                return@submit
             }
             if (! isPreviewed) {
                 mMainHandler.post {
@@ -264,12 +268,9 @@ class CameraUVC(ctx: Context, device: UsbDevice) : MultiCameraClient.ICamera(ctx
                 callback.onBegin()
             }
             val date = mDateFormat.format(System.currentTimeMillis())
-            val title = savePath ?: "IMG_AUSBC_$date"
-            val displayName = savePath ?: "$title.jpg"
-            val path = savePath ?: "$mCameraDir/$displayName"
-            val location = Utils.getGpsLocation(ctx)
             val width = mCameraRequest!!.previewWidth
             val height = mCameraRequest!!.previewHeight
+            val path = savePath ?: "$mCameraDir/IMG_AUSBC_${date}_w${width}_h${height}.jpg"
             val ret = MediaUtils.saveYuv2Jpeg(path, data, width, height)
             if (! ret) {
                 val file = File(path)
@@ -282,14 +283,7 @@ class CameraUVC(ctx: Context, device: UsbDevice) : MultiCameraClient.ICamera(ctx
                 Logger.w(TAG, "save yuv to jpeg failed.")
                 return@submit
             }
-            val values = ContentValues()
-            values.put(MediaStore.Images.ImageColumns.TITLE, title)
-            values.put(MediaStore.Images.ImageColumns.DISPLAY_NAME, displayName)
-            values.put(MediaStore.Images.ImageColumns.DATA, path)
-            values.put(MediaStore.Images.ImageColumns.DATE_TAKEN, date)
-            values.put(MediaStore.Images.ImageColumns.LONGITUDE, location?.longitude)
-            values.put(MediaStore.Images.ImageColumns.LATITUDE, location?.latitude)
-            ctx.contentResolver?.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+            if (savePath.isNullOrEmpty()) MediaStoreUtils.saveMediaStore(File(path), mContext)
             mMainHandler.post {
                 callback.onComplete(path)
             }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
@@ -88,7 +88,7 @@ class Mp4Muxer(
         try {
             if (path.isNullOrEmpty()) {
                 val date = mDateFormat.format(System.currentTimeMillis())
-                path = "$mCameraDir/VID_JJCamera_$date"
+                path = "$mCameraDir/VID_AUSBC_$date"
             }
             mOriginalPath = path
             path = "${path}.mp4"

--- a/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
@@ -28,6 +28,7 @@ import android.provider.MediaStore
 import android.text.format.DateUtils
 import com.jiangdg.ausbc.callback.ICaptureCallBack
 import com.jiangdg.ausbc.utils.Logger
+import com.jiangdg.ausbc.utils.MediaStoreUtils
 import com.jiangdg.ausbc.utils.MediaUtils
 import com.jiangdg.ausbc.utils.Utils
 import java.io.File
@@ -68,13 +69,17 @@ class Mp4Muxer(
     private var mCaptureCallBack: ICaptureCallBack? = null
     private var mMainHandler: Handler = Handler(Looper.getMainLooper())
     private var mOriginalPath: String? = null
+    private var mPathEmpty: Boolean = path.isNullOrEmpty()
     private var mVideoPts: Long = 0L
     private var mAudioPts: Long = 0L
     private val mDateFormat by lazy {
         SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.getDefault())
     }
     private val mCameraDir by lazy {
-        "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)}/Camera"
+        "${mContext!!.getExternalFilesDir(Environment.DIRECTORY_DCIM)}/Camera"
+    }
+    private val mCameraAudioDir by lazy {
+        "${mContext!!.getExternalFilesDir(Environment.DIRECTORY_MUSIC)}/Camera"
     }
 
     init {
@@ -248,33 +253,12 @@ class Mp4Muxer(
             if (videoPath.isNullOrEmpty()) {
                 return
             }
-            ctx.contentResolver.let { content ->
-                val uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-                content.insert(uri, getVideoContentValues(videoPath))
+                if(mPathEmpty) MediaStoreUtils.saveMediaStore(File(videoPath), context)
                 mMainHandler.post {
                     mCaptureCallBack?.onComplete(this.path)
                 }
-            }
         }
     }
-
-    private fun getVideoContentValues(path: String): ContentValues {
-        val file = File(path)
-        val values = ContentValues()
-        values.put(MediaStore.Video.Media.DATA, path)
-        values.put(MediaStore.Video.Media.DISPLAY_NAME, file.name)
-        values.put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
-        values.put(MediaStore.Video.Media.SIZE, file.length())
-        values.put(MediaStore.Video.Media.DURATION, getLocalVideoDuration(file.path))
-        if (MediaUtils.isAboveQ()) {
-            val relativePath =  "${Environment.DIRECTORY_DCIM}${File.separator}Camera"
-            val dateExpires = (System.currentTimeMillis() + DateUtils.DAY_IN_MILLIS) / 1000
-            values.put(MediaStore.Video.Media.RELATIVE_PATH, relativePath)
-            values.put(MediaStore.Video.Media.DATE_EXPIRES, dateExpires)
-        }
-        return values
-    }
-
 
     fun isMuxerStarter() = mVideoTrackerIndex != -1 && (mAudioTrackerIndex != -1 || isVideoOnly)
 

--- a/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/encode/muxer/Mp4Muxer.kt
@@ -253,7 +253,6 @@ class Mp4Muxer(
             if (videoPath.isNullOrEmpty()) {
                 return
             }
-                if(mPathEmpty) MediaStoreUtils.saveMediaStore(File(videoPath), context)
                 mMainHandler.post {
                     mCaptureCallBack?.onComplete(this.path)
                 }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
@@ -424,15 +424,6 @@ class RenderManager(
     private fun saveImageInternal(savePath: String?) {
         if (savePath.isNullOrEmpty()) {
             File(mCameraDir).apply { if(!exists()) mkdirs() }
-            if (!MediaUtils.isAboveQ()) {
-                if (!CameraUtils.hasStoragePermission(mContext)) {
-                    mMainHandler.post {
-                        mCaptureDataCb?.onError("have no storage permission")
-                    }
-                    Logger.e(TAG,"saveImageInternal failed, have no storage permission")
-                    return
-                }
-            }
         }
         if (mCaptureState.get()) {
             return

--- a/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
@@ -476,7 +476,6 @@ class RenderManager(
             mCaptureState.set(false)
             return
         }
-        if (savePath.isNullOrEmpty()) MediaStoreUtils.saveMediaStore(file, mContext)
         mMainHandler.post {
             mCaptureDataCb?.onComplete(path)
         }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
@@ -93,7 +93,10 @@ class RenderManager(
         SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.getDefault())
     }
     private val mCameraDir by lazy {
-        "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)}/Camera"
+        "${mContext.getExternalFilesDir(Environment.DIRECTORY_DCIM)}/Camera"
+    }
+    private val mCameraAudioDir by lazy {
+        "${mContext.getExternalFilesDir(Environment.DIRECTORY_MUSIC)}/Camera"
     }
 
     init {
@@ -421,6 +424,18 @@ class RenderManager(
     }
 
     private fun saveImageInternal(savePath: String?) {
+        if (savePath.isNullOrEmpty()) {
+            File(mCameraDir).apply { if(!exists()) mkdirs() }
+            if (!MediaUtils.isAboveQ()) {
+                if (!CameraUtils.hasStoragePermission(mContext)) {
+                    mMainHandler.post {
+                        mCaptureDataCb?.onError("have no storage permission")
+                    }
+                    Logger.e(TAG,"saveImageInternal failed, have no storage permission")
+                    return
+                }
+            }
+        }
         if (mCaptureState.get()) {
             return
         }
@@ -429,11 +444,9 @@ class RenderManager(
             mCaptureDataCb?.onBegin()
         }
         val date = mDateFormat.format(System.currentTimeMillis())
-        val title = savePath ?: "IMG_AUSBC_$date"
-        val displayName = savePath ?: "$title.jpg"
-        val path = savePath ?: "$mCameraDir/$displayName"
         val width = mWidth
         val height = mHeight
+        val path = savePath ?: "$mCameraDir/IMG_AUSBC_${date}_w${width}_h${height}.jpg"
         // 写入文件
         // glReadPixels读取的是大端数据，但是我们保存的是小端
         // 故需要将图片上下颠倒为正
@@ -465,14 +478,7 @@ class RenderManager(
             mCaptureState.set(false)
             return
         }
-        val values = ContentValues()
-        values.put(MediaStore.Images.ImageColumns.TITLE, title)
-        values.put(MediaStore.Images.ImageColumns.DISPLAY_NAME, displayName)
-        values.put(MediaStore.Images.ImageColumns.DATA, path)
-        values.put(MediaStore.Images.ImageColumns.DATE_TAKEN, date)
-        values.put(MediaStore.Images.ImageColumns.WIDTH, width)
-        values.put(MediaStore.Images.ImageColumns.HEIGHT, height)
-        mContext.contentResolver?.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+        if (savePath.isNullOrEmpty()) MediaStoreUtils.saveMediaStore(file, mContext)
         mMainHandler.post {
             mCaptureDataCb?.onComplete(path)
         }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/render/RenderManager.kt
@@ -15,13 +15,11 @@
  */
 package com.jiangdg.ausbc.render
 
-import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.SurfaceTexture
 import android.opengl.EGLContext
 import android.os.*
-import android.provider.MediaStore
 import android.view.Surface
 import com.jiangdg.ausbc.callback.ICaptureCallBack
 import com.jiangdg.ausbc.callback.IPreviewDataCallBack

--- a/libausbc/src/main/java/com/jiangdg/ausbc/utils/CameraUtils.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/utils/CameraUtils.kt
@@ -114,11 +114,6 @@ object CameraUtils {
         return locPermission == PackageManager.PERMISSION_GRANTED
     }
 
-    fun hasStoragePermission(ctx: Context): Boolean{
-        val locPermission = ContextCompat.checkSelfPermission(ctx, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-        return locPermission == PackageManager.PERMISSION_GRANTED
-    }
-
     fun hasCameraPermission(ctx: Context): Boolean{
         val locPermission = ContextCompat.checkSelfPermission(ctx, Manifest.permission.CAMERA)
         return locPermission == PackageManager.PERMISSION_GRANTED

--- a/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
@@ -89,7 +89,7 @@ object MediaStoreUtils {
         }
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             val storePath = Environment.getExternalStoragePublicDirectory(relativePath).absolutePath
-            val appDir = File(storePath).apply {
+            val appDir = File(storePath, context.packageName).apply {
                 if (!exists()) mkdirs()
             }
             val file = File(appDir, fileName)
@@ -103,7 +103,7 @@ object MediaStoreUtils {
         val contentValues = ContentValues().apply {
             put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
             put(MediaStore.Images.Media.MIME_TYPE, mimeType)
-            put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
+            put(MediaStore.MediaColumns.RELATIVE_PATH, "${relativePath}/${context.packageName}")
         }
         return context.contentResolver?.insert(contentUri, contentValues)!!
     }

--- a/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
@@ -1,0 +1,106 @@
+package com.jiangdg.ausbc.utils
+
+import android.Manifest
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.io.FileInputStream
+import java.util.Locale.getDefault
+import kotlin.text.split
+
+object MediaStoreUtils {
+    private const val TAG = "MediaStoreUtils"
+
+    private fun saveMediaStore(file: File, context: Context) {
+        if (!file.exists()) throw Exception("no find file")
+        val mimeType = MimeTypeMap.getSingleton()
+            .getMimeTypeFromExtension(file.extension.lowercase(getDefault()))
+        if (mimeType == null) throw Exception("no find file mimeType")
+        val mediaList = arrayOf("image", "video", "audio")
+        if (!mediaList.contains(mimeType.split("/").first()))
+            throw Exception("must image/video/audio file")
+        val perG = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        } else {
+            PackageManager.PERMISSION_GRANTED
+        }
+        if (perG != PackageManager.PERMISSION_GRANTED) {
+            throw Exception("must have WRITE_EXTERNAL_STORAGE permission")
+        }
+        val mediaDirs =
+            arrayOf(
+                Environment.DIRECTORY_PICTURES,
+                Environment.DIRECTORY_MOVIES,
+                Environment.DIRECTORY_MUSIC,
+                Environment.DIRECTORY_DCIM,
+            ).map { Environment.getExternalStoragePublicDirectory(it).absolutePath }
+        val isInMediaDirs = mediaDirs.any { dir -> file.absolutePath.startsWith(dir) }
+        if (isInMediaDirs) {
+            MediaScannerConnection.scanFile(
+                context,
+                arrayOf(file.absolutePath),
+                arrayOf(mimeType)
+            ) { _, mediaUri ->
+                Log.d(TAG, "saveMediaStore success: $mediaUri")
+            }
+            return
+        }
+        val mediaUri = createMediaUri(mimeType, file.name, context)
+        context.contentResolver?.openOutputStream(mediaUri)?.use { outputStream ->
+            FileInputStream(file).use { fileInputStream ->
+                val buffer = ByteArray(1024)
+                var bytesRead: Int
+                while (fileInputStream.read(buffer).also { bytesRead = it } > 0) {
+                    outputStream.write(buffer, 0, bytesRead)
+                }
+                outputStream.flush()
+            }
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            MediaScannerConnection.scanFile(
+                context,
+                arrayOf(mediaUri.path),
+                arrayOf(mimeType)
+            ) { _, mediaUri ->
+                Log.d(TAG, "saveMediaStore success: $mediaUri")
+            }
+        }
+        Log.d(TAG, "saveMediaStore success: $mediaUri")
+    }
+
+    private fun createMediaUri(mimeType: String, fileName: String, context: Context): Uri {
+        val relativePath = when {
+            mimeType.startsWith("video") -> Environment.DIRECTORY_MOVIES
+            mimeType.startsWith("audio") -> Environment.DIRECTORY_MUSIC
+            else -> Environment.DIRECTORY_PICTURES
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val storePath = Environment.getExternalStoragePublicDirectory(relativePath).absolutePath
+            val appDir = File(storePath).apply {
+                if (!exists()) mkdirs()
+            }
+            val file = File(appDir, fileName)
+            return Uri.fromFile(file)
+        }
+        val contentUri = when {
+            mimeType.startsWith("video") -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+            mimeType.startsWith("audio") -> MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+            else -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+        }
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+            put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
+        }
+        return context.contentResolver?.insert(contentUri, contentValues)!!
+    }
+}

--- a/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
+++ b/libausbc/src/main/java/com/jiangdg/ausbc/utils/MediaStoreUtils.kt
@@ -20,7 +20,7 @@ import kotlin.text.split
 object MediaStoreUtils {
     private const val TAG = "MediaStoreUtils"
 
-    private fun saveMediaStore(file: File, context: Context) {
+    fun saveMediaStore(file: File, context: Context) {
         if (!file.exists()) throw Exception("no find file")
         val mimeType = MimeTypeMap.getSingleton()
             .getMimeTypeFromExtension(file.extension.lowercase(getDefault()))
@@ -34,7 +34,11 @@ object MediaStoreUtils {
             PackageManager.PERMISSION_GRANTED
         }
         if (perG != PackageManager.PERMISSION_GRANTED) {
-            throw Exception("must have WRITE_EXTERNAL_STORAGE permission")
+//            throw Exception("must have WRITE_EXTERNAL_STORAGE permission")
+            Log.w(TAG, "saveMediaStore failed, no have WRITE_EXTERNAL_STORAGE permission")
+            Log.w(TAG, "saveMediaStore failed, no have WRITE_EXTERNAL_STORAGE permission")
+            Log.w(TAG, "saveMediaStore failed, no have WRITE_EXTERNAL_STORAGE permission")
+            return
         }
         val mediaDirs =
             arrayOf(


### PR DESCRIPTION
- 更改了默认保存位置，尽可能的减少对文件存储权限的依赖，从音频保存位置得到启发，统一默认保存到无需权限的位置
- 保存到媒体存储，<api29需要存储权限，如果没有权限将不保存
- 为了不造成破坏性更新，默认保存下会有两个文件，一个在getExternalFilesDir中，一个在getExternalStoragePublicDirectory中，因为原项目时以文件为核心保存媒体文件的，媒体存储时选择了拷贝一份。
- 我感觉未来可以去除自动保存到媒体存储(这样可以不依赖任何储存权限)。用户自由选择是否需要保存媒体(包括处理<29的存储权限)

translator

- Changed the default save location to minimize dependence on file storage permissions as much as possible, inspired by the audio save location, and unified the default save to a location that does not require permissions.  
- Save to media storage; <API 29 requires storage permission, and it will not save if permission is not granted.  
- To avoid destructive updates, by default two files will be saved: one in getExternalFilesDir and one in getExternalStoragePublicDirectory, because the original project was centered on file-based media storage, and in media storage, a copy was chosen.  
- I feel that in the future, automatic saving to media storage can be removed (thus avoiding any reliance on storage permissions). Users can freely choose whether to save media (including handling storage permissions for <29).
